### PR TITLE
增加 readMultiByteUnsafe readBooleanUnsafe 两个非安全的批量读取函数

### DIFF
--- a/src/main/java/com/github/xingshuangs/iot/protocol/s7/service/PLCNetwork.java
+++ b/src/main/java/com/github/xingshuangs/iot/protocol/s7/service/PLCNetwork.java
@@ -350,11 +350,8 @@ public class PLCNetwork extends TcpClientBasic {
         }
         // 发送和接收的PDU编号一致
         if (ackHeader.getPduReference() != req.getHeader().getPduReference()) {
-            if (enableStrictlySafeRead) {
-                // pdu引用编号不一致，数据有误
-                throw new S7CommException("The PDU references are inconsistent, causing incorrect data");
-            }
-            log.warn("The PDU references are inconsistent, causing incorrect data: req[{}], ack[{}]", req.getHeader().getPduReference(), ackHeader.getPduReference());
+            // pdu引用编号不一致，数据有误
+            throw new S7CommException("The PDU references are inconsistent, causing incorrect data");
         }
         if (ack.getDatum() == null) {
             return;

--- a/src/main/java/com/github/xingshuangs/iot/protocol/s7/service/S7PLC.java
+++ b/src/main/java/com/github/xingshuangs/iot/protocol/s7/service/S7PLC.java
@@ -125,6 +125,18 @@ public class S7PLC extends PLCNetwork {
     }
 
     /**
+     * Multi-address reads byte data. Unsafe mode, use with caution!!
+     * (多地址读取字节数据) 非安全模式，如果某个地址读取不到，对应的列表索引返回是null
+     *
+     * @param addressRead address wrapper list
+     * @return byte array list
+     */
+    public List<byte[]> readMultiByteUnsafe(MultiAddressRead addressRead) {
+        List<DataItem> dataItems = this.readS7DataUnsafe(addressRead.getRequestItems());
+        return dataItems.stream().map(DataItem::getData).collect(Collectors.toList());
+    }
+
+    /**
      * Read byte.
      * (单地址字节数据读取)
      *
@@ -182,6 +194,17 @@ public class S7PLC extends PLCNetwork {
         List<RequestItem> requestItems = addresses.stream().map(AddressUtil::parseBit).collect(Collectors.toList());
         List<DataItem> dataItems = this.readS7Data(requestItems);
         return dataItems.stream().map(x -> BooleanUtil.getValue(x.getData()[0], 0)).collect(Collectors.toList());
+    }
+
+    public List<Boolean> readBooleanUnsafe(String... address) {
+        return this.readBooleanUnsafe(Arrays.asList(address));
+    }
+
+    public List<Boolean> readBooleanUnsafe(List<String> addresses) {
+        List<RequestItem> requestItems = addresses.stream().map(AddressUtil::parseBit).collect(Collectors.toList());
+        List<DataItem> dataItems = this.readS7DataUnsafe(requestItems);
+        return dataItems.stream().map(x -> !EReturnCode.SUCCESS.equals(x.getReturnCode()) ? null :
+                BooleanUtil.getValue(x.getData()[0], 0)).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
增加 readMultiByteUnsafe readBooleanUnsafe 两个非安全的批量读取函数。
允许在批量读取的时候，如果某个点位地址出现问题，不直接抛异常，而是将对应的索引置为null，让调用方自行处理。