### PR TITLE
Fixed wrong buffer length to process timer/counter response.

### DIFF
--- a/src/main/java/com/github/xingshuangs/iot/protocol/s7/model/RequestItem.java
+++ b/src/main/java/com/github/xingshuangs/iot/protocol/s7/model/RequestItem.java
@@ -98,6 +98,11 @@ public class RequestItem extends RequestBaseItem {
      */
     private int bitAddress = 0;
 
+    public int getByteCount() {
+        int multiplier = EParamVariableType.TIMER.equals(this.variableType) || EParamVariableType.COUNTER.equals(this.variableType) ? 2 : 1;
+        return count * multiplier;
+    }
+
     @Override
     public int byteArrayLength() {
         return BYTE_LENGTH;

--- a/src/main/java/com/github/xingshuangs/iot/protocol/s7/service/PLCNetwork.java
+++ b/src/main/java/com/github/xingshuangs/iot/protocol/s7/service/PLCNetwork.java
@@ -384,7 +384,7 @@ public class PLCNetwork extends TcpClientBasic {
         // 根据原始请求列表提取每个请求数据大小
         List<Integer> rawNumbers = requestItems.stream().map(RequestItem::getCount).collect(Collectors.toList());
         // 根据原始请求列表构建最终结果列表
-        List<DataItem> resultList = requestItems.stream().map(x -> DataItem.createReq(new byte[x.getCount()],
+        List<DataItem> resultList = requestItems.stream().map(x -> DataItem.createReq(new byte[x.getByteCount()],
                         x.getVariableType() == EParamVariableType.BIT ? EDataVariableType.BIT : EDataVariableType.BYTE_WORD_DWORD))
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
I am trying to read counter/timer data from S7 PLC, but this line of code cause ArrayOutOfBoundException while copying response buffer (for more details look at the screenshot).
```
plcController.readS7Data(AddressUtil.parse(tagConfiguration.plcAddress(), 2, EParamVariableType.TIMER)
```
![s7error](https://github.com/user-attachments/assets/de6c0315-755f-471b-a9aa-6a63e76d3c30)
